### PR TITLE
Updating conditions for when linting and semgrep workflows are triggered

### DIFF
--- a/workflow-templates/linting.yml
+++ b/workflow-templates/linting.yml
@@ -1,7 +1,11 @@
 name: Linting
-on: [push]
+on: [push, pull_request]
 jobs:
-  lint:
+  lint: 
+    # Run per push for internal contributers. This isn't possible for forked pull requests,
+    # so we'll need to run on PR events for external contributers.
+    # String comparison below is case insensitive.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
     steps:
      - uses: 'phantomcyber/dev-cicd-tools/github-actions/lint@main'

--- a/workflow-templates/semgrep.yml
+++ b/workflow-templates/semgrep.yml
@@ -1,6 +1,10 @@
 name: Semgrep
 on: 
-  pull_request:
+  pull_request_target:
+    branches:
+      - next
+      - main
+  push:
     branches:
       - next
       - main
@@ -8,7 +12,17 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     steps:
+     - if: github.event_name == 'push'
+       run: |
+        echo "REPOSITORY=${{ github.repository }}" >> $GITHUB_ENV
+        echo "REF=${{ github.REF }}" >> $GITHUB_ENV
+     - if: github.event_name == 'pull_request_target'
+       run: |
+        echo "REPOSITORY=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+        echo "REF=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
      - uses: 'phantomcyber/dev-cicd-tools/github-actions/semgrep@main'
        with: 
         SEMGREP_DEPLOYMENT_ID: ${{ secrets.SEMGREP_DEPLOYMENT_ID }}
         SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+        REPOSITORY: ${{ github.repository }} 
+        REF: ${{ github.ref }}


### PR DESCRIPTION
### Notes
- Our Semgrep scans use our Semgrep account ID and token, which are loaded as secrets. The issue is that by default, workflows triggered from a forked repo don't have access to them. To get around this, I'm updating the event type to [```pull_request_target```](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) from ```pull_request```, and explicitly checking out the forked code using ```pull_request.head.repo.full_name``` and ```pull_request.head.ref```
- Configuring Semgrep to also run on pushes to ```next``` and ```main``` which will scan the entire repo, whereas only the updated lines are scanned on a ```pull_request``` event
- Configuring linting to run on ```pull_request``` events for forked repos/external contributors

### Testing
- https://github.com/Splunk-SOAR-Apps/phawslambda/pull/3